### PR TITLE
Mobile Compatibility for Header drop-down menu, Sponsors page, Home intro container

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { Gradient } from './assets/Gradient.js';
+import { Gradient } from "./assets/Gradient.js";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import Home from "./components/Home";
@@ -10,18 +10,17 @@ import Join from "./components/Join";
 import "./App.css";
 import Competition from "./components/Competition";
 
-
 function App() {
-  const gradient = new Gradient()
-  gradient.initGradient('#gradient-canvas')
+  useEffect(() => {
+    const gradient = new Gradient();
+    gradient.initGradient("#gradient-canvas");
+  }, []);
 
   return (
-
     <div className="app-container">
-
-    <div id="animated-bg">
-      <canvas id="gradient-canvas" data-transition-in></canvas>
-    </div>
+      <div id="animated-bg">
+        <canvas id="gradient-canvas" data-transition-in></canvas>
+      </div>
 
       <div className="content">
         <Router>
@@ -37,7 +36,6 @@ function App() {
         </Router>
       </div>
     </div>
-
   );
 }
 

--- a/client/src/stylesheets/Header.css
+++ b/client/src/stylesheets/Header.css
@@ -1,72 +1,76 @@
-.Header{
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    /* height: auto; */
+.Header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* height: auto; */
 }
 
-.links{
-    list-style: none;
-    font-size: 24px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    margin: 0;
-    padding: 0;
+.links {
+  list-style: none;
+  font-size: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin: 0;
+  padding: 0;
 }
 
-.links li{
-    margin-right: 4em;
+.links li {
+  margin-right: 4em;
 }
 
-.nav{
-} 
+.nav {
+}
 
 .menu-icon {
-    display: none; 
+  display: none;
 }
 
-.fimenu{
-    background: transparent;  
-    border: none;
-    outline: none;  
-    padding: 10px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
+.fimenu {
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
 }
 
-.fimenu:focus, .fimenu:active {
+.fimenu:focus,
+.fimenu:active {
+  outline: none;
+  border: none;
+  box-shadow: none;
+}
+
+@media only screen and (max-width: 850px) {
+  .menu-icon {
+    display: block;
+    border: none;
     outline: none;
-    border: none;
-    box-shadow: none; 
-}
+  }
 
-@media only screen and (max-width: 850px){
-    
-    .menu-icon {
-        display: block; 
-        border: none;
-        outline: none;
-    }
-    
-    .nav .links {
-        display: none;
-        flex-direction: column;
-        /* background:#e1e1e1; */
-        background:white;
-        position: absolute;
-        top: 100px;
-        left: 0;
-        width: 100%;
-        padding: 10px 0;
-        text-align: center;
-    }
+  .nav .links {
+    display: none;
+    flex-direction: column;
+    /* background:#e1e1e1; */
+    background: #e1e1e1;
+    position: absolute;
+    top: 100px;
+    left: 0;
+    width: 100%;
+    padding: 10px 0;
+    text-align: center;
+  }
 
-    .nav.open .links {
-        display: flex;
-    }
+  .nav.open .links {
+    display: flex;
+  }
+
+  .links li {
+    margin-right: 0em;
+  }
 }

--- a/client/src/stylesheets/Header.css
+++ b/client/src/stylesheets/Header.css
@@ -57,7 +57,7 @@
     display: none;
     flex-direction: column;
     /* background:#e1e1e1; */
-    background: #e1e1e1;
+    background-color: rgba(225, 225, 225, 0.95);
     position: absolute;
     top: 100px;
     left: 0;
@@ -68,6 +68,8 @@
 
   .nav.open .links {
     display: flex;
+    /* display on top */
+    z-index: 99;
   }
 
   .links li {

--- a/client/src/stylesheets/Home.css
+++ b/client/src/stylesheets/Home.css
@@ -26,3 +26,13 @@
   line-height: 1;
   max-width: 100rem;
 }
+
+@media only screen and (max-width: 850px) {
+  .intro-container h2 {
+    font-size: 3rem;
+  }
+
+  .intro-container p {
+    font-size: 1.5rem;
+  }
+}

--- a/client/src/stylesheets/Home.css
+++ b/client/src/stylesheets/Home.css
@@ -1,40 +1,28 @@
 .intro-container {
-  background-color: #e1e1e1; 
+  background-color: #e1e1e1;
   text-align: left; /* Keep text alignment to the left */
   margin-top: 20%;
   margin-bottom: 20%;
   padding: 4%;
+  box-shadow: 0px 4px 2.3px 4px rgba(0, 0, 0, 0.25),
+    0px 4px 4px 5px rgba(0, 0, 0, 0.25) inset;
 }
 
 .intro-container .content {
   max-width: 800px; /* Keep a manageable max width */
-  text-align: left; 
+  text-align: left;
   max-width: fit-content;
 }
 .intro-container h2 {
-  font-size: 4rem; 
-  color: #5632a6; 
-  margin-bottom: 1rem; 
+  font-size: 4rem;
+  color: #5632a6;
+  margin-bottom: 1rem;
   font-weight: bold;
 }
 
 .intro-container p {
-  font-size: 3rem; 
-  color: #333333; 
-  line-height: 1.; 
+  font-size: 3rem;
+  color: #333333;
+  line-height: 1;
   max-width: 100rem;
- }
-
-
- 
-
-
-
-
- 
-
- 
-  
-  
-
-  
+}

--- a/client/src/stylesheets/Sponsors.css
+++ b/client/src/stylesheets/Sponsors.css
@@ -1,61 +1,61 @@
-
-.Sponsors{
-    background-color: #E1E1E1;
-    width: 100%;
-    padding: 40px;
-    text-align: center;
-    margin-top: 10%;
-    padding-bottom: 5%;
-    margin-bottom: 10%;
+.Sponsors {
+  background-color: #e1e1e1;
+  width: 100%;
+  padding: 40px;
+  text-align: center;
+  margin-top: 10%;
+  padding-bottom: 5%;
+  margin-bottom: 10%;
+  box-shadow: 0px 4px 2.3px 4px rgba(0, 0, 0, 0.25),
+    0px 4px 4px 5px rgba(0, 0, 0, 0.25) inset;
 }
 
-.heading{
-    font-weight: 400;
-    font-size: 48px;
-    line-height: 58.09px;
-    color:#5632A6 ;
+.heading {
+  font-weight: 400;
+  font-size: 48px;
+  line-height: 58.09px;
+  color: #5632a6;
 }
 
-.logos{
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+.logos {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.sponsor{
-    position: relative;
-    margin: 20px 0;
+.sponsor {
+  position: relative;
+  margin: 20px 0;
 }
 
-.roboshop-logo{
-    width: 50%;
-    max-width: 866px;
-    height: auto;
+.roboshop-logo {
+  width: 50%;
+  max-width: 866px;
+  height: auto;
 }
 
-.digikey-logo{
-    width: 40%;
-    max-width: 591px;
-    height: auto;
+.digikey-logo {
+  width: 40%;
+  max-width: 591px;
+  height: auto;
 }
 
 @media (max-width: 768px) {
-    .roboshop-logo {
-        width: 80%;
-    }
+  .roboshop-logo {
+    width: 80%;
+  }
 
-    .digikey-logo {
-        width: 60%;
-    }
+  .digikey-logo {
+    width: 60%;
+  }
 }
 
 @media (max-width: 480px) {
-    .roboshop-logo {
-        width: 90%;
-    }
+  .roboshop-logo {
+    width: 90%;
+  }
 
-    .digikey-logo {
-        width: 70%;
-    }
+  .digikey-logo {
+    width: 70%;
+  }
 }
-

--- a/client/src/stylesheets/Sponsors.css
+++ b/client/src/stylesheets/Sponsors.css
@@ -1,13 +1,15 @@
 .Sponsors {
   background-color: #e1e1e1;
   width: 100%;
-  padding: 40px;
   text-align: center;
   margin-top: 10%;
   padding-bottom: 5%;
   margin-bottom: 10%;
   box-shadow: 0px 4px 2.3px 4px rgba(0, 0, 0, 0.25),
     0px 4px 4px 5px rgba(0, 0, 0, 0.25) inset;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .heading {
@@ -31,31 +33,13 @@
 .roboshop-logo {
   width: 50%;
   max-width: 866px;
+  min-width: 300px;
   height: auto;
 }
 
 .digikey-logo {
   width: 40%;
   max-width: 591px;
+  min-width: 200px;
   height: auto;
-}
-
-@media (max-width: 768px) {
-  .roboshop-logo {
-    width: 80%;
-  }
-
-  .digikey-logo {
-    width: 60%;
-  }
-}
-
-@media (max-width: 480px) {
-  .roboshop-logo {
-    width: 90%;
-  }
-
-  .digikey-logo {
-    width: 70%;
-  }
 }


### PR DESCRIPTION
Improved Mobile Compatibility for:

- Sponsors Page
  - Fixed Margin
  - Fixed Image Sizing
- Home Intro Container
  - Text Sizing
- Header drop-down menu

  - Centered menu items
  - Forced to display on top of page content
  - Add translucency for aesthetic (just felt right)

Screenshots:
Sponsors Page
![SponsorsMobile](https://github.com/user-attachments/assets/728e4cdd-4a09-41ea-b384-b6fe5ac928ff)
Home Intro Container
![IntroContainerMobile](https://github.com/user-attachments/assets/29175886-9352-4ac1-a656-e197f2ee8aac)
Header Drop-Down Menu (Overlaying with Sponsors Page)
![HamburgerMenuMobile](https://github.com/user-attachments/assets/e7fff9b8-e0f7-44fe-a411-5bfae0c342da)
